### PR TITLE
Fix the delete operation for the Mongo adapter

### DIFF
--- a/Mongo_Adapter/CRUD/Delete.cs
+++ b/Mongo_Adapter/CRUD/Delete.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using MongoDB.Driver;
 using BH.oM.Data.Requests;
 using BH.Engine.Mongo;
+using MongoDB.Bson;
 
 namespace BH.Adapter.Mongo
 {
@@ -35,7 +36,12 @@ namespace BH.Adapter.Mongo
 
         public override int Delete(FilterRequest filter, Dictionary<string, object> config = null)
         {
-            DeleteResult result = m_Collection.DeleteMany(filter.ToMongoQuery());
+            BsonDocument query = filter.ToMongoQuery();
+            BsonDocument request = query.GetElement("$match").Value.AsBsonDocument;
+            if (query == null)
+                return 0;
+
+            DeleteResult result = m_Collection.DeleteMany(request);
             return (int)result.DeletedCount;
         }
 


### PR DESCRIPTION
   
### Issues addressed by this PR

Closes #70


### Test files
Simply run the delete operation on any of your Mongo database.

### Additional comments
Two things will change in a near future:
- the delete operation will accept any IRequest instead of just the FilterRequest
- the FilterRequest will loose its Equalities property

But this fixes the problem for the time being.