### PR TITLE
Provide feedback if MongoAdapter fails to establish a connection to the server

### DIFF
--- a/Mongo_Adapter/MongoAdapter.cs
+++ b/Mongo_Adapter/MongoAdapter.cs
@@ -55,6 +55,11 @@ namespace BH.Adapter.Mongo
                 serverName = "mongodb://" + serverName;
 
             m_Client = new MongoClient(serverName + ":" + port.ToString());
+
+            if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
+                throw new MongoException($"Connection to the host server {serverName} " +
+                    $"on port {port} failed");
+
             IMongoDatabase database = m_Client.GetDatabase(databaseName);
             m_Collection = database.GetCollection<BsonDocument>(collectionName);
 
@@ -83,6 +88,10 @@ namespace BH.Adapter.Mongo
             MongoClientSettings settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
             settings.SslSettings = new SslSettings { EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 };
             m_Client = new MongoClient(settings);
+
+            if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
+                throw new MongoException($"Connection to the host server {settings.Server.Host} " +
+                    $"on port {settings.Server.Port} failed using credentials {settings.Credentials}");
 
             IMongoDatabase database = m_Client.GetDatabase(databaseName);
             m_Collection = database.GetCollection<BsonDocument>(collectionName);

--- a/Mongo_Adapter/MongoAdapter.cs
+++ b/Mongo_Adapter/MongoAdapter.cs
@@ -57,8 +57,11 @@ namespace BH.Adapter.Mongo
             m_Client = new MongoClient(serverName + ":" + port.ToString());
 
             if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
-                throw new MongoException($"Connection to the host server {serverName} " +
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Connection to the host server {serverName} " +
                     $"on port {port} failed");
+                return;
+            }
 
             IMongoDatabase database = m_Client.GetDatabase(databaseName);
             m_Collection = database.GetCollection<BsonDocument>(collectionName);
@@ -90,8 +93,11 @@ namespace BH.Adapter.Mongo
             m_Client = new MongoClient(settings);
 
             if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
-                throw new MongoException($"Connection to the host server {settings.Server.Host} " +
+            {
+                Engine.Reflection.Compute.RecordError($"Connection to the host server {settings.Server.Host} " +
                     $"on port {settings.Server.Port} failed using credentials {settings.Credentials}");
+                return;
+            }
 
             IMongoDatabase database = m_Client.GetDatabase(databaseName);
             m_Collection = database.GetCollection<BsonDocument>(collectionName);

--- a/Mongo_Adapter/Mongo_Adapter.csproj
+++ b/Mongo_Adapter/Mongo_Adapter.csproj
@@ -57,6 +57,10 @@
       <HintPath>..\packages\MongoDB.Driver.Core.2.4.4\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Reflection_Engine, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Reflection_oM, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #79 
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
1. Open grasshopper
2. Instantiate a `MongoAdapter` component from a connection string
3. Input a nonsense in in the string, such as `thisisanonsensurl.com:27017`

Otherwise, if you have a server somewhere that requires authentication, you can try connect to it by creating the string `{username}:{password}@hostaddress:port/database` and use a wrong password.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `MongoAdapter` from `connectionString` now checks if the connections is actually valid
- `MongoAdapter` from `host` and `port` now checks if the connections is actually valid
