### PR TITLE
Fix error message when first creating the adapter

### DIFF
--- a/Mongo_Adapter/MongoAdapter.cs
+++ b/Mongo_Adapter/MongoAdapter.cs
@@ -25,6 +25,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using System.ComponentModel;
 using BH.oM.Adapter.Mongo;
+using System.Threading;
 
 namespace BH.Adapter.Mongo
 {
@@ -57,6 +58,16 @@ namespace BH.Adapter.Mongo
 
             m_Client = new MongoClient(serverName + ":" + port.ToString());
 
+            // Give it maximum 5 seconds to establish connection 
+            for (int i = 0; i < 50; i++)
+            {
+                if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
+                    Thread.Sleep(100);
+                else
+                    break;
+            }
+
+            // Consider the server is unavailable if connection failed after 5 seconds
             if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
             {
                 BH.Engine.Reflection.Compute.RecordError($"Connection to the host server {serverName} " +
@@ -93,6 +104,16 @@ namespace BH.Adapter.Mongo
             settings.SslSettings = new SslSettings { EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 };
             m_Client = new MongoClient(settings);
 
+            // Give it maximum 5 seconds to establish connection 
+            for (int i = 0; i < 50; i++)
+            {
+                if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
+                    Thread.Sleep(100);
+                else
+                    break;
+            }
+
+            // Consider the server is unavailable if connection failed after 5 seconds
             if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
             {
                 Engine.Reflection.Compute.RecordError($"Connection to the host server {settings.Server.Host} " +


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #95

Fix the error that was introduce by https://github.com/BHoM/Mongo_Toolkit/pull/80

Now gives time for the connection to be established before testing it (maximum 5 seconds with check interval of 100 ms).

### Test
Create a file where you read data from a database (you can use the London or Hong Kong ones if you don't have Mongo locally), save it and see that when you restart Rhino and GH, you will have to reconnect the input for the component to work. With this PR, it should work without the need to reconnect.
 


