### PR TITLE
Remove reference to AdapterIdName in the constructor

### DIFF
--- a/Mongo_Adapter/MongoAdapter.cs
+++ b/Mongo_Adapter/MongoAdapter.cs
@@ -50,7 +50,6 @@ namespace BH.Adapter.Mongo
         [Output("adapter", "Adapter to Mongo Database")]
         public MongoAdapter(string serverName = "mongodb://localhost", int port = 27017, string databaseName = "project", string collectionName = "bhomObjects", bool useHistory = true)
         {
-            AdapterIdName = "Mongo_id";
 
             if (!serverName.StartsWith("mongodb://"))
                 serverName = "mongodb://" + serverName;
@@ -95,7 +94,6 @@ namespace BH.Adapter.Mongo
         public MongoAdapter(string connectionString, string databaseName = "project", string collectionName = "bhomObjects", bool useHistory = false)
         {
 
-            AdapterIdName = "Mongo_id";
             if (!connectionString.StartsWith("mongodb://"))
                 connectionString = "mongodb://" + connectionString;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #126 

<!-- Add short description of what has been fixed -->

Removing reference to AdapterNameId being removed in https://github.com/BHoM/BHoM_Adapter/pull/263

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->