### PR TITLE
Updated Mongo Adapter to not Add "mongodb://" to Connection String

### DIFF
--- a/Mongo_Adapter/MongoAdapter.cs
+++ b/Mongo_Adapter/MongoAdapter.cs
@@ -94,9 +94,6 @@ namespace BH.Adapter.Mongo
         public MongoAdapter(string connectionString, string databaseName = "project", string collectionName = "bhomObjects", bool useHistory = false)
         {
 
-            if (!connectionString.StartsWith("mongodb://"))
-                connectionString = "mongodb://" + connectionString;
-
             MongoClientSettings settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
             settings.SslSettings = new SslSettings { EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 };
             m_Client = new MongoClient(settings);


### PR DESCRIPTION


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #145

Removed the check where mongodb:// was added to the front end of connection string. 


### Test files
Test with any connection to a Mongo Atlas or similar where the connection string doesn't begin with mongodb://. 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->