### PR TITLE
Mongo_Adapter: postbuild events to only include mongo-related DLLs

### DIFF
--- a/Mongo_Adapter/Mongo_Adapter.csproj
+++ b/Mongo_Adapter/Mongo_Adapter.csproj
@@ -133,7 +133,16 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
-xcopy "$(TargetDir)*.dll"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+xcopy "Crc32C.NET.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "DnsClient.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "MongoDB.Bson.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "MongoDB.Driver.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "MongoDB.Driver.Core.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "SharpCompress.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "Snappy.NET.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "System.Buffers.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+xcopy "System.Runtime.InteropServices.RuntimeInformation.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
+</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #161 

<!-- Add short description of what has been fixed -->

The build events in Mongo_Adapter include non-mongo DLLs copies, which can cause compilation errors (see #161), because of this line:
```
xcopy "$(TargetDir)*.dll"  "C:\ProgramData\BHoM\Assemblies"
```

This PR updates build events of Mongo_Adapter to only include mongo-related DLLs.


### Test files
<!-- Link to test files to validate the proposed changes -->
Testing only requires compiling and using any existing Mongo_Toolkit script to check that it is working, e.g. script found in #160 .

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Updated build events of Mongo_Adapter to only include mongo-related DLLs.

### Additional comments
<!-- As required -->