### PR TITLE
Return an error if the Push type is not supported

### DIFF
--- a/Mongo_Adapter/AdapterActions/Push.cs
+++ b/Mongo_Adapter/AdapterActions/Push.cs
@@ -44,6 +44,18 @@ namespace BH.Adapter.Mongo
             if (m_Client.Cluster.Description.State == MongoDB.Driver.Core.Clusters.ClusterState.Disconnected)
                 return new List<object>();
 
+            // Make sure that the push type is supported
+            if (pushType != PushType.AdapterDefault && pushType != PushType.DeleteThenCreate && pushType != PushType.CreateOnly && pushType != PushType.UpdateOrCreateOnly)
+            {
+                BH.Engine.Base.Compute.RecordError($"{this.GetType().Name} only supports the following {nameof(PushType)}s:" +
+                    $"\n\t- {nameof(PushType.CreateOnly)} => appends content (default setting)" +
+                    $"\n\t- {nameof(PushType.DeleteThenCreate)} => replaces all content" +
+                    $"\n\t- {nameof(PushType.UpdateOrCreateOnly)} => upsert" +
+                    $"\nEvery other {nameof(PushType)} will behave as {nameof(PushType.CreateOnly)}.");
+
+                return new List<object>();
+            }
+                
             // Create the bulk query for the object to replace/insert
             DateTime timestamp = DateTime.Now;
             IEnumerable<BsonDocument> documents = objects.Select(x => Engine.Adapters.Mongo.Convert.ToBson(x, tag, timestamp));
@@ -69,13 +81,6 @@ namespace BH.Adapter.Mongo
             }
             else
                 m_Collection.InsertMany(documents);
-
-            if (pushType != PushType.AdapterDefault && pushType != PushType.DeleteThenCreate && pushType != PushType.CreateOnly && pushType != PushType.UpdateOrCreateOnly)
-                BH.Engine.Base.Compute.RecordNote($"{this.GetType().Name} only supports the following {nameof(PushType)}s:" +
-                    $"\n\t- {nameof(PushType.CreateOnly)} => appends content (default setting)" +
-                    $"\n\t- {nameof(PushType.DeleteThenCreate)} => replaces all content" +
-                    $"\n\t- {nameof(PushType.UpdateOrCreateOnly)} => upsert" +
-                    $"\nEvery other {nameof(PushType)} will behave as {nameof(PushType.CreateOnly)}.");
 
             // Push in the history database as well
             if (m_History != null)


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #168

Error now returned when push type is not supported:
![image](https://github.com/BHoM/Mongo_Toolkit/assets/16853390/22681416-f1a4-4902-8579-96ade59fd9a6)


### Test files
[PushTypeErrorMessage_Test.zip](https://github.com/BHoM/Mongo_Toolkit/files/13901785/PushTypeErrorMessage_Test.zip)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->